### PR TITLE
Removed unpassable test

### DIFF
--- a/src/unittest/python/rhyme_thyme_tests.py
+++ b/src/unittest/python/rhyme_thyme_tests.py
@@ -4,9 +4,6 @@ from rhyme_thyme import RhymeThyme
 
 class test_rhyme_thyme(unittest.TestCase):
 
-    def test_rhyme_thyme(self):
-        self.assertEqual(RhymeThyme.rhyme_thyme(self,'abcd'), 'Thyme\n', 'Not returning rhyming word')
-
     def test_goodbye(self):
         text = 'Goodbye!\n'
         self.assertEqual(RhymeThyme.print_goodbye_text(self), text, 'Not printing goodbye text properly!')


### PR DESCRIPTION
The existing test for rhyme_thyme was checking to see if the program would output "Thyme\n" as a rhyme word for "abcd", which (hopefully) never is the case. As having no test at all is better than having one which fails by default, I suggest simply removing it. After removing it, all tests run successfully on my machine (using Windows and "pyb_", no less).

I thought about how the rhyming functionality could be properly tested, and I'm not sure how. Given that there would, in theory, exist an infinite number of "words" rhyming with any other word, how would we even test it? One idea is to isolate one or a couple of words in the database that have a very well defined set of words rhyming with them (preferably small sets) and check if the result is within that set. Still, that could fail if the database is updated. In addition to this, many words can be pronounced in different ways, which again leaves us with a non-definitive result. 

All in all, I think having access to the phonetic spelling of each word is the only way to really test this - only then can the pronunciation (and thus rhyming) be invariably determined.